### PR TITLE
Fix getModeConfigFile

### DIFF
--- a/src/main/java/org/pageseeder/berlioz/GlobalSettings.java
+++ b/src/main/java/org/pageseeder/berlioz/GlobalSettings.java
@@ -170,6 +170,9 @@ public final class GlobalSettings {
   }
 
   /**
+   * @note: If the appData is different of webInf then maybe the mode config could be in other folder. Therefore in this
+   * case should be worth to check in {appData}/config
+   *
    * @return The configuration directory containing all configuration files for Berlioz.
    */
   public static File getConfig() {
@@ -227,7 +230,11 @@ public final class GlobalSettings {
    */
   public static @Nullable File getModeConfigFile() {
     if (env == null) return null;
-    File f = getModeConfigFile(getConfig());
+    File appDataConfigDirectory = env.appData().toPath().resolve(env.configFolder()).toFile();
+    File f = getModeConfigFile(appDataConfigDirectory);
+    if (f == null || !f.exists()) {
+      f = getModeConfigFile(getConfig());
+    }
     return f;
   }
 

--- a/src/test/java/org/pageseeder/berlioz/GlobalSettingsTest.java
+++ b/src/test/java/org/pageseeder/berlioz/GlobalSettingsTest.java
@@ -33,7 +33,8 @@ public final class GlobalSettingsTest {
 
   @Before
   public void setup() {
-    File webinf = new File(this.getClass().getResource("/org/pageseeder/berlioz").getFile());
+    File webinf = new File("src/test/resources/org/pageseeder/berlioz");
+    System.out.println(webinf.getAbsolutePath());
     InitEnvironment env = InitEnvironment.create(webinf).mode("default");
     GlobalSettings.setup(env);
   }


### PR DESCRIPTION
GlobalSettings.getModeConfigFile always returns the the mode config from web-inf/config however if the appData is not the web-inf then the mode config file could be in the appData/config instead of web-inf/config.

This fix first check if the mode config is in the appData/config and if not returns the one in web-inf/config.